### PR TITLE
read_pdfminder 함수 수정

### DIFF
--- a/groove/README
+++ b/groove/README
@@ -1,1 +1,1 @@
-Please visit https://magenta.tensorflow.org/datasets/groove
+Pease visit https://magenta.tensorflow.org/datasets/groove


### PR DESCRIPTION
## 상세 내용

- PDF파일에 폰트 식별자가 포함되지 않은 페이지에서 텍스트 추출이 되지 않는 문제가 발생
- read_pdfminder 함수에 인코딩 방식을 수동으로 지정해주는 코드를 추가하여 위 문제를 해결

## 질문

- 질문사항1
- 질문사항2